### PR TITLE
Add no_extra_blank_lines throw, use, and use_trait rules

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -61,7 +61,14 @@ class Config extends \PhpCsFixer\Config
             'native_function_casing' => true,
             'no_blank_lines_after_class_opening' => true,
             'no_blank_lines_after_phpdoc' => true,
-            'no_extra_blank_lines' => true,
+            'no_extra_blank_lines' => [
+                'tokens' => [
+                    'extra',
+                    'throw',
+                    'use',
+                    'use_trait',
+                ],
+            ],
             'no_closing_tag' => true,
             'no_empty_phpdoc' => true,
             'no_empty_statement' => true,


### PR DESCRIPTION
These rules correspond to StyleCI's no_blank_lines_after_throw, no_blank_lines_between_imports, and no_blank_lines_between_traits rules.

The mapping for the 'no blank' rules is:

`no_blank_lines_after_class_opening`: `no_blank_lines_after_class_opening`
`no_blank_lines_after_phpdoc`: `no_blank_lines_after_phpdoc`
`no_blank_lines_after_throw`: `no_extra_blank_lines => ['tokens' => ['throw']`
`no_blank_lines_between_imports`: `no_extra_blank_lines => ['tokens' => ['use']`
`no_blank_lines_between_traits`: `no_extra_blank_lines => ['tokens' => ['use_trait']`
`no_extra_consecutive_blank_lines`: `no_extra_blank_lines => ['tokens' => ['extra'] `

Closes #4.

