### PR TITLE
Add list_syntax rule

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -47,6 +47,9 @@ class Config extends \PhpCsFixer\Config
             'ordered_imports' => [
                 'sort_algorithm' => 'length',
             ],
+            'list_syntax' => [
+                'syntax' => 'short',
+            ],
             'lowercase_cast' => true,
             'lowercase_constants' => true,
             'lowercase_keywords' => true,


### PR DESCRIPTION
Add `list_syntax` rule for the equivalent [StyleCI Laravel preset](https://docs.styleci.io/presets#laravel) rule `short_list_syntax`.