### PR TITLE
Add PHP 7.4 to the Travis CI test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 ## Cache composer
 cache:


### PR DESCRIPTION
Since the issue with PHP CS Fixer not running on PHP 7.4 (mentioned in ac5dcc39c41f7a12665dda8aafb7a40e2bc2e7a0) has now been fixed, it's probably worth testing this package on PHP 7.4 as well. 👍