### PR TITLE
Add support for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "friendsofphp/php-cs-fixer": "^2.14"
     },
     "require-dev": {
-        "laravel/framework": "^6.0.3|^7.0",
+        "laravel/framework": "^7.0",
         "phpunit/phpunit": "^7.0"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     },
     "require": {
         "php": ">=7.2",
-        "illuminate/support": "5.7.x|5.8.x|^6.0",
+        "illuminate/support": "5.7.x|5.8.x|^6.0|^7.0",
         "friendsofphp/php-cs-fixer": "^2.14"
     },
     "require-dev": {
-        "laravel/framework": "^6.0.3",
+        "laravel/framework": "^6.0.3|^7.0",
         "phpunit/phpunit": "^7.0"
     },
     "extra": {


### PR DESCRIPTION
This updates to use Laravel 7 for testing in preperation for Laravel Code Style v0.6.x when Laravel 7 releases on March 3rd (in theory). 👍

I'm also wondering if it's worth bumping PHPUnit to `^8.0|^9.0` (PHPUnit 9 requires PHP 7.3, so probably best to keep PHPUnit 8 support for now).