### PR TITLE
Output more helpful test failures

### DIFF
--- a/tests/FormattingTest.php
+++ b/tests/FormattingTest.php
@@ -13,29 +13,27 @@ class FormattingTest extends TestCase
 {
     public function test_formatting_matches_laravel()
     {
-        $application = new Application();
-        $application->setAutoExit(false);
+        $application = tap(new Application())->setAutoExit(false);
+        $exitCode = $application->run(
+            new ArrayInput([
+                'command' => 'fix',
+                'path' => [__DIR__.'/../vendor/laravel/framework'],
+                '--config' => __DIR__.'/fixtures/.php_cs',
+                '--dry-run' => true,
+                '--diff' => true,
+                '--verbose' => true,
+            ]),
+            $output = new BufferedOutput()
+        );
 
-        $input = new ArrayInput([
-           'command' => 'fix',
-           'path' => [__DIR__.'/../vendor/laravel/framework'],
-           '--config' => __DIR__.'/fixtures/.php_cs',
-           '--dry-run' => true,
-           '--format' => 'json',
-        ]);
-
-        $output = new BufferedOutput();
-        $application->run($input, $output);
-
-        $content = json_decode($output->fetch(), true);
-
-        $files = array_map(function (array $file) {
-            return $file['name'];
-        }, $content['files']);
-
-        $this->assertEmpty(
-            $files,
-            'Existing Laravel files should not need to be fixed.'
+        $this->assertEquals(
+            0,
+            $exitCode,
+            implode(PHP_EOL, [
+                'Existing Laravel files should not need to be fixed.',
+                'Output:',
+                $output->fetch(),
+            ])
         );
     }
 }


### PR DESCRIPTION
Show a diff & the applied rules when tests fail, i.e.

```
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.13
Configuration: /Users/matt/code/laravel-code-style/phpunit.xml.dist

F                                                                   1 / 1 (100%)

Time: 176 ms, Memory: 14.00 MB

There was 1 failure:

1) MattAllan\LaravelCodeStyle\FormattingTest::test_formatting_matches_laravel
Existing Laravel files should not need to be fixed.
Output:
Loaded config Laravel from "/Users/matt/code/laravel-code-style/tests/fixtures/.php_cs".
Using cache file ".php_cs.cache".
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSFSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Legend: ?-unknown, I-invalid file syntax (file ignored), S-skipped (cached or empty file), .-no changes, F-fixed, E-error
   1) vendor/laravel/framework/src/Illuminate/Contracts/Auth/Access/Authorizable.php (blank_line_after_opening_tag)
      ---------- begin diff ----------
--- Original
+++ New
@@ @@
 <?php
+
 namespace Illuminate\Contracts\Auth\Access;
 
 interface Authorizable
 {
     /**
      * Determine if the entity has a given ability.
      *
      * @param  string  $ability
      * @param  array|mixed  $arguments
      * @return bool
      */
     public function can($ability, $arguments = []);
 }
 

      ----------- end diff -----------


Checked all files in 0.068 seconds, 14.000 MB memory used

Failed asserting that 8 matches expected 0.

/Users/matt/code/laravel-code-style/tests/FormattingTest.php:35

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```