### PR TITLE
Add support for Laravel 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   phpunit:
-    name: Testing (PHP ${{ matrix.php-versions }})
+    name: Testing (PHP ${{ matrix.php-versions }} / Laravel ${{ matrix.laravel-versions }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -16,6 +16,10 @@ jobs:
       max-parallel: 15
       matrix:
         php-versions: ['7.2', '7.3', '7.4']
+        laravel-versions: [^7.0, ^8.0]
+        exclude:
+          - php-versions: 7.2
+            laravel-versions: ^8.0
         include:
           - php-versions: 7.2
             dependency-version: "--prefer-lowest --prefer-stable"
@@ -36,6 +40,11 @@ jobs:
 
       - name: Validate Composer files
         run: composer validate
+
+      - name: Update composer.json
+        run: |
+          composer require illuminate/support:${{ matrix.laravel-versions }} --no-update
+          composer require --dev laravel/framework:${{ matrix.laravel-versions }} --no-update
 
       - name: Install dependencies
         run: composer update ${{ matrix.dependency-version }}  --prefer-dist --no-interaction --no-progress --no-suggest

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     },
     "require": {
         "php": ">=7.2",
-        "illuminate/support": "5.7.x|5.8.x|^6.0|^7.0",
+        "illuminate/support": "5.7.x|5.8.x|^6.0|^7.0|^8.0",
         "friendsofphp/php-cs-fixer": "^2.14"
     },
     "require-dev": {
-        "laravel/framework": "^7.0",
+        "laravel/framework": "^7.0|^8.0",
         "phpunit/phpunit": "^7.0"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     },
     "require-dev": {
         "laravel/framework": "^7.0|^8.0",
-        "phpunit/phpunit": "^7.0"
+        "orchestra/testbench": "^5.0|^6.0",
+        "phpunit/phpunit": "^7.0|^8.0"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -47,5 +47,7 @@
     },
     "config": {
         "sort-packages": true
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MattAllan\LaravelCodeStyle;
+
+use Illuminate\Filesystem\Filesystem;
+use Mockery;
+use Orchestra\Testbench\TestCase;
+
+class ServiceProviderTest extends TestCase
+{
+    public function test_service_provider_boots(): void
+    {
+        $mockFileSystem = $this->mock(Filesystem::class);
+        $this->instance('files', $mockFileSystem);
+
+        $mockFileSystem
+            ->shouldReceive('isFile')
+            ->with(Mockery::on(static function ($a) {
+                return strpos($a, 'config/.php_cs') > 0;
+            }))
+            ->andReturn(true)
+            ->once();
+        $mockFileSystem->shouldReceive('exists')->andReturn(false)->once();
+        $mockFileSystem->shouldReceive('isDirectory')->andReturn(true)->once();
+        $mockFileSystem->shouldReceive('copy')->once();
+
+        $this->artisan('vendor:publish', [
+            '--provider' => ServiceProvider::class,
+        ]);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            ServiceProvider::class,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Add support for Laravel 8
- composer: allow installing dev dependencies, but prefer stable
- add orchestra/testbench
- add test for publishing :muscle:
- expand github actions test matrix to test against actual Laravel versions