### PR TITLE
Update php-cs-fixer for composer 2.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     },
     "require": {
         "php": ">=7.2",
-        "illuminate/support": "5.7.x|5.8.x|^6.0|^7.0|^8.0",
-        "friendsofphp/php-cs-fixer": "^2.14"
+        "friendsofphp/php-cs-fixer": "^2.15.6",
+        "illuminate/support": "5.7.x|5.8.x|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "brick/varexporter": "^0.3.2",


### PR DESCRIPTION
Pulls in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4905 to address the issue described here: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5238, which is causing test failures when dependencies are installed using `--prefer-lowest --prefer-stable`.