### PR TITLE
PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": ">=7.2",
+        "php": "^7.2|^8.0",
         "friendsofphp/php-cs-fixer": "^2.15.6",
         "illuminate/support": "5.7.x|5.8.x|^6.0|^7.0|^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": "^7.2|^8.0",
-        "friendsofphp/php-cs-fixer": "^2.15.6",
+        "friendsofphp/php-cs-fixer": "^2.17.1",
         "illuminate/support": "5.7.x|5.8.x|^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
As a new version of `friendsofphp/php-cs-fixer` supporting PHP 8 has recently been released, I thought we could update this package too. However, it appears that we're still blocked by `styleci/sdk`.

Should we wait (no idea for how long) for `styleci/sdk` to support PHP 8, or could we (temporarily?) revert to manual rule selection and remove the dependency for now (and possibly just keep the current rules)? Anyway, it would be nice if this package could be used again (had to remove it from all the projects I upgraded to PHP 8).

Thoughts @matt-allan?

Edit: it seems `php-cs-fixer` doesn't fully support PHP 8 yet.