### PR TITLE
Remove old version illuminate/support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 15
       matrix:
         php-versions: ['7.3', '7.4', '8.0']
-        laravel-versions: [^5.7, ^5.8, ^6.0, ^7.0, ^8.0]
+        laravel-versions: [^7.0, ^8.0]
         include:
           - php-versions: 7.3
             dependency-version: "--prefer-lowest --prefer-stable"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 15
       matrix:
         php-versions: ['7.3', '7.4', '8.0']
-        laravel-versions: [^7.0, ^8.0]
+        laravel-versions: [^5.7, ^5.8, ^6.0, ^7.0, ^8.0]
         include:
           - php-versions: 7.3
             dependency-version: "--prefer-lowest --prefer-stable"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-main": "1.0-dev"
         },
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "brick/varexporter": "^0.3.2",
         "laravel/framework": "^7.0|^8.0",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^5.0|^6.0",
         "phpunit/phpunit": "^7.0|^8.0",
         "styleci/sdk": "^1.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=7.3",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "illuminate/support": "5.7.x|5.8.x|^6.0|^7.0|^8.0"
+        "illuminate/support": "^7.0|^8.0"
     },
     "require-dev": {
         "brick/varexporter": "^0.3.2",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.0-dev"
+            "dev-master": "1.0-dev"
         },
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "brick/varexporter": "^0.3.2",
         "laravel/framework": "^7.0|^8.0",
-        "orchestra/testbench": "^5.0|^6.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^7.0|^8.0",
         "styleci/sdk": "^1.3"
     },


### PR DESCRIPTION
orchestra/testbench v5 required illuminate/support ^7.30.3, see https://github.com/realodix/laravel-code-style/runs/2984119587?check_suite_focus=true

**Just info**
Considering Laravel v6 is LTS and still supported until [September 6th, 2022](https://endoflife.date/laravel), I did a test run by [installing orchestra/testbench v4](https://github.com/realodix/laravel-code-style/commit/0723fb27da695223284e134bb15c623ff18bb1e3), see https://github.com/realodix/laravel-code-style/runs/2984140808?check_suite_focus=true