### PR TITLE
Update rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "friendsofphp/php-cs-fixer": "^3.0",
+        "friendsofphp/php-cs-fixer": "^3.2.0",
         "illuminate/support": "^7.0|^8.0"
     },
     "require-dev": {

--- a/src/Config.php
+++ b/src/Config.php
@@ -35,7 +35,7 @@ class Config extends \PhpCsFixer\Config
                 ],
             ],
             'cast_spaces' => true,
-            'class_definition' => true,
+            'class_definition' => false,
             'clean_namespace' => true,
             'compact_nullable_typehint' => true,
             'concat_space' => [
@@ -56,9 +56,7 @@ class Config extends \PhpCsFixer\Config
             'heredoc_to_nowdoc' => true,
             'include' => true,
             'indentation_type' => true,
-            'braces' => [
-                'allow_single_line_anonymous_class_with_empty_body' => true,
-            ],
+            'braces' => false,
             'lowercase_cast' => true,
             'constant_case' => [
                 'case' => 'lower',
@@ -67,7 +65,9 @@ class Config extends \PhpCsFixer\Config
             'lowercase_static_reference' => true,
             'magic_constant_casing' => true,
             'magic_method_casing' => true,
-            'method_argument_space' => true,
+            'method_argument_space' => [
+                'on_multiline' => 'ignore',
+            ],
             'class_attributes_separation' => [
                 'elements' => [
                     'method' => 'one',
@@ -101,6 +101,7 @@ class Config extends \PhpCsFixer\Config
             'multiline_whitespace_before_semicolons' => true,
             'no_short_bool_cast' => true,
             'no_singleline_whitespace_before_semicolons' => true,
+            'no_space_around_double_colon' => true,
             'no_spaces_after_function_name' => true,
             'no_spaces_around_offset' => [
                 'positions' => [

--- a/src/Config.php
+++ b/src/Config.php
@@ -89,7 +89,6 @@ class Config extends \PhpCsFixer\Config
                 'tokens' => [
                     'throw',
                     'use',
-                    'use_trait',
                     'extra',
                 ],
             ],
@@ -176,6 +175,9 @@ class Config extends \PhpCsFixer\Config
             ],
             'trim_array_spaces' => true,
             'unary_operator_spaces' => true,
+            'types_spaces' => [
+                'space' => 'none',
+            ],
             'line_ending' => true,
             'whitespace_after_comma_in_array' => true,
         ],

--- a/src/Config.php
+++ b/src/Config.php
@@ -56,6 +56,7 @@ class Config extends \PhpCsFixer\Config
             'heredoc_to_nowdoc' => true,
             'include' => true,
             'indentation_type' => true,
+            'integer_literal_case' => true,
             'braces' => false,
             'lowercase_cast' => true,
             'constant_case' => [

--- a/src/Dev/GenerateRules.php
+++ b/src/Dev/GenerateRules.php
@@ -21,6 +21,9 @@ class GenerateRules
      */
     const UNRELEASED_RULES = [
         'phpdoc_singular_inheritdoc',
+        // See https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/89106bccfb33fdac02397f231966f37d14bf4e07
+        'integer_literal_case',
+
     ];
 
     /**
@@ -187,6 +190,11 @@ class GenerateRules
                 'operators' => [
                     '=' => 'single_space',
                 ],
+            ],
+        ],
+        'union_type_without_spaces' => [
+            'types_spaces' => [
+                'space' => 'none',
             ],
         ],
         'unix_line_endings' => [

--- a/src/Dev/GenerateRules.php
+++ b/src/Dev/GenerateRules.php
@@ -60,6 +60,10 @@ class GenerateRules
                 ],
             ],
         ],
+        'class_definition' => [
+            // TODO: re-enable once it doesn't break anonymous classes
+            'class_definition' => false,
+        ],
         'concat_without_spaces' => [
             'concat_space' => [
                 'spacing' => 'none',
@@ -77,13 +81,39 @@ class GenerateRules
             'indentation_type' => true,
         ],
         'laravel_braces' => [
-            'braces' => [
-                'allow_single_line_anonymous_class_with_empty_body' => true,
-            ],
+            // TODO: enable once braces fixers are split
+            // See https://github.com/matt-allan/laravel-code-style/issues/47
+            'braces' => false,
+            // 'braces' => [
+            //     'allow_single_line_anonymous_class_with_empty_body' => true,
+            // ],
+        ],
+        'laravel_phpdoc_alignment' => [
+            // TODO: use 2 spaces after w/ vertical alignment
+            // Need to write a new fixer?
+            // See https://docs.styleci.io/fixers#laravel_phpdoc_alignment
+            // 'phpdoc_align' => false,
+        ],
+        'laravel_phpdoc_order' => [
+            // TODO: enable once other phpdoc rules work
+            // @param, then @return, then @throws
+            // See https://docs.styleci.io/fixers#laravel_phpdoc_order
+            // 'phpdoc_order' => true,
+        ],
+        'laravel_phpdoc_separation' => [
+            // TODO: separate but group @param and @return
+            // Need to fork https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/07430f5aca4874476bf175317cfb6284cd80421a/src/DocBlock/TagComparator.php
+            // See https://docs.styleci.io/fixers#laravel_phpdoc_separation
+            // 'phpdoc_separation' => false,
         ],
         'lowercase_constants' => [
             'constant_case' => [
                 'case' => 'lower',
+            ],
+        ],
+        'method_argument_space' => [
+            'method_argument_space' => [
+                'on_multiline' => 'ignore',
             ],
         ],
         'method_separation' => [

--- a/src/Dev/GenerateRules.php
+++ b/src/Dev/GenerateRules.php
@@ -20,6 +20,12 @@ class GenerateRules
      * released version of PHP-CS-Fixer.
      */
     const UNRELEASED_RULES = [
+        // https://docs.styleci.io/fixers#laravel_phpdoc_alignment
+        'laravel_phpdoc_alignment',
+        // https://docs.styleci.io/fixers#laravel_phpdoc_order
+        'laravel_phpdoc_order',
+        // https://docs.styleci.io/fixers#laravel_phpdoc_separation
+        'laravel_phpdoc_separation',
         'phpdoc_singular_inheritdoc',
     ];
 
@@ -81,27 +87,6 @@ class GenerateRules
             // TODO: enable once braces fixers are split
             // See https://github.com/matt-allan/laravel-code-style/issues/47
             'braces' => false,
-            // 'braces' => [
-            //     'allow_single_line_anonymous_class_with_empty_body' => true,
-            // ],
-        ],
-        'laravel_phpdoc_alignment' => [
-            // TODO: use 2 spaces after w/ vertical alignment
-            // Need to write a new fixer?
-            // See https://docs.styleci.io/fixers#laravel_phpdoc_alignment
-            // 'phpdoc_align' => false,
-        ],
-        'laravel_phpdoc_order' => [
-            // TODO: enable once other phpdoc rules work
-            // @param, then @return, then @throws
-            // See https://docs.styleci.io/fixers#laravel_phpdoc_order
-            // 'phpdoc_order' => true,
-        ],
-        'laravel_phpdoc_separation' => [
-            // TODO: separate but group @param and @return
-            // Need to fork https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/07430f5aca4874476bf175317cfb6284cd80421a/src/DocBlock/TagComparator.php
-            // See https://docs.styleci.io/fixers#laravel_phpdoc_separation
-            // 'phpdoc_separation' => false,
         ],
         'lowercase_constants' => [
             'constant_case' => [

--- a/src/Dev/GenerateRules.php
+++ b/src/Dev/GenerateRules.php
@@ -21,9 +21,6 @@ class GenerateRules
      */
     const UNRELEASED_RULES = [
         'phpdoc_singular_inheritdoc',
-        // See https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/89106bccfb33fdac02397f231966f37d14bf4e07
-        'integer_literal_case',
-
     ];
 
     /**

--- a/tests/FormattingTest.php
+++ b/tests/FormattingTest.php
@@ -14,7 +14,7 @@ class FormattingTest extends TestCase
 {
     public function test_formatting_matches_laravel()
     {
-        if (((int) substr(Laravel::VERSION, 0, 1)) < 8) {
+        if (version_compare(Laravel::VERSION, '8.59.0') < 0) {
             $this->markTestSkipped('Formatting is not up to date for old Laravel versions');
         }
 

--- a/tests/FormattingTest.php
+++ b/tests/FormattingTest.php
@@ -18,8 +18,6 @@ class FormattingTest extends TestCase
             $this->markTestSkipped('Formatting is not up to date for old Laravel versions');
         }
 
-        $this->markTestSkipped('Waiting on upstream, see #47');
-
         $application = tap(new Application())->setAutoExit(false);
         $exitCode = $application->run(
             new ArrayInput([


### PR DESCRIPTION
This PR gets the formatting tests passing again and pulls in the latest Style CI changes. There are separate issues for all of the rules that can't be ported yet because they don't work with PHP-CS-Fixer.