### PR TITLE
Drop PHP 7.3 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       max-parallel: 15
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.4', '8.0']
         laravel-versions: [^7.0, ^8.0]
         include:
-          - php-versions: 7.3
+          - php-versions: 7.4
             dependency-version: "--prefer-lowest --prefer-stable"
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "friendsofphp/php-cs-fixer": "^3.0",
         "illuminate/support": "^7.0|^8.0"
     },


### PR DESCRIPTION
Security support is dropped in 11 days for PHP 7.3 and the package won't work on 7.3 anymore without a lot of work because of new fixers that don't work with that version of PHP-CS-Fixer.